### PR TITLE
Hw 7: Object Model of Resume.

### DIFF
--- a/objectModelOfResume.uml
+++ b/objectModelOfResume.uml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Diagram>
+  <ID>JAVA</ID>
+  <OriginalElement>/Users/avs/repo/basejava</OriginalElement>
+  <nodes>
+    <node x="876.5405437573194" y="1153.14772946666">ru.javawebinar.basejava.model.sections.ListInfoSection</node>
+    <node x="85.19637146268218" y="982.9263174966607">ru.javawebinar.basejava.model.Resume</node>
+    <node x="553.8324203891488" y="569.9415515127707">ru.javawebinar.basejava.model.item.Info</node>
+    <node x="445.0640160474361" y="1333.4468107507046">ru.javawebinar.basejava.model.enumKeyTypes.SectionType</node>
+    <node x="1148.6658888555194" y="1333.4468107507046">ru.javawebinar.basejava.model.enumKeyTypes.InfoType</node>
+    <node x="1457.7797940772657" y="1333.4468107507046">ru.javawebinar.basejava.model.enumKeyTypes.ContactType</node>
+    <node x="714.1063161550043" y="762.2845748819462">ru.javawebinar.basejava.model.item.Item</node>
+    <node x="1700.3847555032162" y="779.1915978170821">ru.javawebinar.basejava.model.interfaces.Section</node>
+    <node x="1076.5683691322545" y="1030.0988901171502">ru.javawebinar.basejava.model.sections.ListStringSection</node>
+    <node x="1350.8450174878024" y="1153.14772946666">ru.javawebinar.basejava.model.sections.ListItemSection</node>
+    <node x="814.5519836337731" y="1334.0705439567332">ru.javawebinar.basejava.model.enumKeyTypes.HeaderType</node>
+    <node x="-226.37108651059214" y="712.8228680964671">ru.javawebinar.basejava.model.interfaces.Chapter</node>
+    <node x="170.0259485213871" y="711.7592439611533">ru.javawebinar.basejava.model.chapters.Contacts</node>
+    <node x="106.96976159488665" y="367.8673399202822">ru.javawebinar.basejava.model.chapters.AbstractEnumChapter</node>
+    <node x="1241.5992918384156" y="762.2845748819462">ru.javawebinar.basejava.model.sections.AbstractListSection</node>
+    <node x="-269.18543520516016" y="1114.0766537497811">ru.javawebinar.basejava.model.chapters.Sections</node>
+    <node x="1695.243208453774" y="1003.3192042838932">ru.javawebinar.basejava.model.sections.TextSection</node>
+    <node x="386.99965740182733" y="927.9051990903347">ru.javawebinar.basejava.model.item.Header</node>
+    <node x="631.8823702974684" y="1157.6760049205195">ru.javawebinar.basejava.model.interfaces.KeyType</node>
+  </nodes>
+  <notes />
+  <edges>
+    <edge source="ru.javawebinar.basejava.model.Resume" target="ru.javawebinar.basejava.model.chapters.Contacts" relationship="TO_ONE">
+      <point x="0.0" y="-202.5" />
+      <point x="209.69637146268218" y="906.342780728907" />
+      <point x="209.6963714626822" y="906.342780728907" />
+      <point x="-86.82957705870493" y="59.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.Resume" target="ru.javawebinar.basejava.model.chapters.Contacts" relationship="CREATE">
+      <point x="86.82957705870493" y="-202.5" />
+      <point x="0.0" y="59.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.Resume" target="ru.javawebinar.basejava.model.chapters.Sections" relationship="CREATE">
+      <point x="-124.5" y="2.6503362531204857" />
+      <point x="124.5" y="15.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.chapters.AbstractEnumChapter" target="ru.javawebinar.basejava.model.interfaces.Chapter" relationship="REALIZATION">
+      <point x="-190.5" y="0.0" />
+      <point x="-79.87108651059214" y="517.8673399202821" />
+      <point x="0.0" y="-71.5" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.sections.ListItemSection" target="ru.javawebinar.basejava.model.sections.AbstractListSection" relationship="GENERALIZATION">
+      <point x="-24.86040926419446" y="-31.836280543513794" />
+      <point x="1467.984608223608" y="1098.4558988215235" />
+      <point x="1426.0049058450593" y="1098.4558988215235" />
+      <point x="36.905614006643646" y="98.50005609041375" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.sections.TextSection" target="ru.javawebinar.basejava.model.interfaces.Section" relationship="REALIZATION">
+      <point x="-121.49973748861044" y="2.3242119243604975E-4" />
+      <point x="1655.0" y="1088.3194367050855" />
+      <point x="1655.0" y="811.1915054088303" />
+      <point x="-90.00032943323959" y="-9.240825181677792E-5" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.enumKeyTypes.SectionType" target="ru.javawebinar.basejava.model.interfaces.KeyType" relationship="REALIZATION">
+      <point x="4.98185788273986E-4" y="-85.49981075070468" />
+      <point x="584.0645142332244" y="1270.0" />
+      <point x="705.3825202595561" y="1270.0" />
+      <point x="1.4996208778939035E-4" y="31.99951211996313" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.chapters.Contacts" target="ru.javawebinar.basejava.model.chapters.AbstractEnumChapter" relationship="GENERALIZATION">
+      <point x="126.49962564129234" y="-2.4396115327363077E-4" />
+      <point x="511.0" y="770.759" />
+      <point x="511.0" y="517.8671164274322" />
+      <point x="190.50023840511338" y="-2.2349284995470953E-4" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.item.Header" target="ru.javawebinar.basejava.model.chapters.AbstractEnumChapter" relationship="GENERALIZATION">
+      <point x="3.425981726650207E-4" y="-58.99984502334894" />
+      <point x="511.0" y="517.8671164274322" />
+      <point x="190.50023840511338" y="-2.2349284995470953E-4" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.enumKeyTypes.HeaderType" target="ru.javawebinar.basejava.model.interfaces.KeyType" relationship="REALIZATION">
+      <point x="-1.61382897204021E-4" y="-85.50035515751392" />
+      <point x="953.051822250876" y="1270.0" />
+      <point x="705.3825202595561" y="1270.0" />
+      <point x="1.4996208778939035E-4" y="31.99951211996313" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.sections.ListStringSection" target="ru.javawebinar.basejava.model.sections.AbstractListSection" relationship="GENERALIZATION">
+      <point x="1.3119876211931114E-4" y="32.000386100750234" />
+      <point x="1230.0685003310166" y="1125.0" />
+      <point x="1426.0049058450593" y="1125.0" />
+      <point x="36.905614006643646" y="98.50005609041375" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.enumKeyTypes.InfoType" target="ru.javawebinar.basejava.model.interfaces.KeyType" relationship="REALIZATION">
+      <point x="-4.6780288766967715E-4" y="-85.50026624846487" />
+      <point x="1274.6654210526317" y="1270.0" />
+      <point x="705.3825202595561" y="1270.0" />
+      <point x="1.4996208778939035E-4" y="31.99951211996313" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.item.Item" target="ru.javawebinar.basejava.model.sections.ListInfoSection" relationship="TO_ONE">
+      <point x="15.0" y="124.5" />
+      <point x="956.6063161550043" y="1153.14772946666" />
+      <point x="89.11401801171974" y="-32.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.item.Item" target="ru.javawebinar.basejava.model.item.Header" relationship="TO_ONE">
+      <point x="-227.5" y="100.12062420838845" />
+      <point x="124.0" y="0.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.chapters.Sections" target="ru.javawebinar.basejava.model.sections.TextSection" relationship="CREATE">
+      <point x="0.0" y="59.0" />
+      <point x="-144.68543520516016" y="1594.765266248465" />
+      <point x="1878.2034843001554" y="1594.765266248465" />
+      <point x="61.460275846381364" y="85.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.chapters.Sections" target="ru.javawebinar.basejava.model.chapters.AbstractEnumChapter" relationship="GENERALIZATION">
+      <point x="-9.430042194935595E-5" y="-58.999653749781146" />
+      <point x="-144.6855295055821" y="873.323" />
+      <point x="511.0" y="873.323" />
+      <point x="511.0" y="517.8671164274322" />
+      <point x="190.50023840511338" y="-2.2349284995470953E-4" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.enumKeyTypes.ContactType" target="ru.javawebinar.basejava.model.interfaces.KeyType" relationship="REALIZATION">
+      <point x="-6.522962298309267" y="-86.18484088502396" />
+      <point x="1592.2568317789564" y="1270.0" />
+      <point x="705.3825202595561" y="1270.0" />
+      <point x="1.4996208778939035E-4" y="31.99951211996313" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.item.Item" target="ru.javawebinar.basejava.model.sections.ListInfoSection" relationship="CREATE">
+      <point x="0.0" y="124.5" />
+      <point x="941.6063161550043" y="1153.14772946666" />
+      <point x="74.11401801171974" y="-32.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.Resume" target="ru.javawebinar.basejava.model.chapters.Sections" relationship="TO_ONE">
+      <point x="-124.5" y="-12.349663746879514" />
+      <point x="124.5" y="0.0" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.sections.AbstractListSection" target="ru.javawebinar.basejava.model.interfaces.Section" relationship="REALIZATION">
+      <point x="147.4996140066437" y="5.609041375009838E-5" />
+      <point x="1655.0" y="860.78463097236" />
+      <point x="1655.0" y="811.1915054088303" />
+      <point x="-90.00032943323959" y="-9.240825181677792E-5" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.item.Info" target="ru.javawebinar.basejava.model.chapters.AbstractEnumChapter" relationship="GENERALIZATION">
+      <point x="-111.49992278149324" y="1.7994998472659063E-4" />
+      <point x="511.0" y="628.9417314627555" />
+      <point x="511.0" y="517.8671164274322" />
+      <point x="190.50023840511338" y="-2.2349284995470953E-4" />
+    </edge>
+    <edge source="ru.javawebinar.basejava.model.sections.ListInfoSection" target="ru.javawebinar.basejava.model.sections.AbstractListSection" relationship="GENERALIZATION">
+      <point x="-2.90736643364653E-5" y="-31.999559419339676" />
+      <point x="1014.540514683655" y="1125.0" />
+      <point x="1426.0049058450593" y="1125.0" />
+      <point x="36.905614006643646" y="98.50005609041375" />
+    </edge>
+  </edges>
+  <settings layout="Hierarchic" zoom="0.9724699495928655" showDependencies="true" x="968.5000000000001" y="979.5" />
+  <SelectedNodes />
+  <Categories>
+    <Category>Constructors</Category>
+    <Category>Fields</Category>
+    <Category>Inner Classes</Category>
+    <Category>Methods</Category>
+    <Category>Properties</Category>
+  </Categories>
+  <SCOPE>All</SCOPE>
+  <VISIBILITY>private</VISIBILITY>
+</Diagram>
+

--- a/src/ru/javawebinar/basejava/model/Resume.java
+++ b/src/ru/javawebinar/basejava/model/Resume.java
@@ -7,8 +7,6 @@ import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
 import ru.javawebinar.basejava.model.interfaces.Section;
 
 import java.util.EnumMap;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -47,16 +45,16 @@ public class Resume implements Comparable<Resume> {
      * @return Collections.unmodifiableSet.
      * Attempting to modify will result in an UnsupportedOperationException in runtime.
      */
-    public Set<Map.Entry<ContactType, String>> getContacts() {
-        return contacts.getAll();
+    public Contacts getContacts() {
+        return contacts;
     }
 
     /**
      * @return Collections.unmodifiableSet. Lists which contains in ListSections is unmodifiable too.
      * Attempting to modify will result in an UnsupportedOperationException in runtime.
      */
-    public Set<Map.Entry<SectionType, Section>> getSections() {
-        return sections.getAll();
+    public Sections getSections() {
+        return sections;
     }
 
     public void setContacts(EnumMap<ContactType, String> contacts) {

--- a/src/ru/javawebinar/basejava/model/Resume.java
+++ b/src/ru/javawebinar/basejava/model/Resume.java
@@ -1,5 +1,14 @@
 package ru.javawebinar.basejava.model;
 
+import ru.javawebinar.basejava.model.chapters.Contacts;
+import ru.javawebinar.basejava.model.chapters.Sections;
+import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
+import ru.javawebinar.basejava.model.interfaces.Section;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -11,6 +20,10 @@ public class Resume implements Comparable<Resume> {
     private final String uuid;
     private final String fullName;
 
+    private final Contacts contacts;
+
+    private final Sections sections;
+
     public Resume(String fullName) {
         this(UUID.randomUUID().toString(), fullName);
     }
@@ -18,6 +31,8 @@ public class Resume implements Comparable<Resume> {
     public Resume(String uuid, String fullName) {
         this.uuid = uuid;
         this.fullName = fullName;
+        contacts = new Contacts();
+        sections = new Sections();
     }
 
     public String getUuid() {
@@ -26,6 +41,22 @@ public class Resume implements Comparable<Resume> {
 
     public String getFullName() {
         return fullName;
+    }
+
+    public Set<Map.Entry<ContactType, String>> getContacts() {
+        return contacts.getAll();
+    }
+
+    public Set<Map.Entry<SectionType, Section>> getSections() {
+        return sections.getAll();
+    }
+
+    public void setContacts(EnumMap<ContactType, String> contacts) {
+        this.contacts.addAll(contacts);
+    }
+
+    public void setSections(EnumMap<SectionType, Section> sections) {
+        this.sections.addAll(sections);
     }
 
     @Override
@@ -45,7 +76,7 @@ public class Resume implements Comparable<Resume> {
 
     @Override
     public String toString() {
-        return uuid;
+        return String.format("%s\n%s\n%s\n%s", fullName, uuid, contacts, sections);
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/Resume.java
+++ b/src/ru/javawebinar/basejava/model/Resume.java
@@ -43,10 +43,18 @@ public class Resume implements Comparable<Resume> {
         return fullName;
     }
 
+    /**
+     * @return Collections.unmodifiableSet.
+     * Attempting to modify will result in an UnsupportedOperationException in runtime.
+     */
     public Set<Map.Entry<ContactType, String>> getContacts() {
         return contacts.getAll();
     }
 
+    /**
+     * @return Collections.unmodifiableSet. Lists which contains in ListSections is unmodifiable too.
+     * Attempting to modify will result in an UnsupportedOperationException in runtime.
+     */
     public Set<Map.Entry<SectionType, Section>> getSections() {
         return sections.getAll();
     }

--- a/src/ru/javawebinar/basejava/model/Resume.java
+++ b/src/ru/javawebinar/basejava/model/Resume.java
@@ -58,11 +58,11 @@ public class Resume implements Comparable<Resume> {
     }
 
     public void setContacts(EnumMap<ContactType, String> contacts) {
-        this.contacts.addAll(contacts);
+        this.contacts.save(contacts);
     }
 
     public void setSections(EnumMap<SectionType, Section> sections) {
-        this.sections.addAll(sections);
+        this.sections.save(sections);
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -33,7 +33,7 @@ public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapt
 
     @Override
     public Set<Map.Entry<K, V>> getAll() {
-        return Collections.unmodifiableSet(chapter.entrySet());
+        return Collections.unmodifiableMap(Objects.requireNonNull(chapter)).entrySet();
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -1,0 +1,6 @@
+package ru.javawebinar.basejava.model.chapters;
+
+import ru.javawebinar.basejava.model.interfaces.Chapter;
+
+public class AbstractEnumChapter<K extends Enum<K>, V> implements Chapter<K, V> {
+}

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -2,23 +2,60 @@ package ru.javawebinar.basejava.model.chapters;
 
 import ru.javawebinar.basejava.model.interfaces.Chapter;
 
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-public class AbstractEnumChapter<K extends Enum<K>, V> implements Chapter<K, V> {
-    @Override
-    public String getTitle(K key) {
-        return null;
+/**
+ * Base class for Contacts and Sections chapter of Resume
+ * and for Header and Info chapters of Item for ListItemSection.
+ *
+ * @param <K> Search key type - Enum.
+ * @param <V> any reference data type.
+ */
+
+public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapter<K, V> {
+    private final EnumMap<K, V> chapter;
+
+    protected AbstractEnumChapter(EnumMap<K, V> chapter) {
+        this.chapter = chapter;
     }
 
     @Override
-    public void addAll(EnumMap<K, V> items) {
+    public String getTitle(K key) {
+        return title(key);
+    }
 
+    protected abstract String title(K key);
+
+    @Override
+    public void addAll(EnumMap<K, V> items) {
+        this.chapter.putAll(Objects.requireNonNull(items));
     }
 
     @Override
     public Set<Map.Entry<K, V>> getAll() {
-        return null;
+        return Collections.unmodifiableSet(chapter.entrySet());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractEnumChapter<?, ?> that = (AbstractEnumChapter<?, ?>) o;
+
+        return chapter.equals(that.chapter);
+    }
+
+    @Override
+    public int hashCode() {
+        return chapter.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder chapter = new StringBuilder();
+        getAll().forEach((item) ->
+                chapter.append(getTitle(item.getKey())).append("\n").append(item.getValue()).append("\n"));
+        return chapter.toString();
     }
 }

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -2,5 +2,23 @@ package ru.javawebinar.basejava.model.chapters;
 
 import ru.javawebinar.basejava.model.interfaces.Chapter;
 
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
 public class AbstractEnumChapter<K extends Enum<K>, V> implements Chapter<K, V> {
+    @Override
+    public String getTitle(K key) {
+        return null;
+    }
+
+    @Override
+    public void addAll(EnumMap<K, V> items) {
+
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> getAll() {
+        return null;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -35,6 +35,9 @@ public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapt
 
     @Override
     public void addAll(EnumMap<K, V> items) {
+        if (!chapter.isEmpty()) {
+            throw new UnsupportedOperationException("Unable to execute addAll(). The content already exists.");
+        }
         this.chapter.putAll(Objects.requireNonNull(items));
     }
 

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -34,7 +34,7 @@ public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapt
     protected abstract V getDefault();
 
     @Override
-    public void addAll(EnumMap<K, V> items) {
+    public void save(EnumMap<K, V> items) {
         if (!chapter.isEmpty()) {
             throw new UnsupportedOperationException("Unable to execute addAll(). The content already exists.");
         }

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -50,7 +50,7 @@ public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapt
 
         AbstractEnumChapter<?, ?> that = (AbstractEnumChapter<?, ?>) o;
 
-        return chapter.equals(that.chapter);
+        return getAll().equals(that.getAll());
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
+++ b/src/ru/javawebinar/basejava/model/chapters/AbstractEnumChapter.java
@@ -27,6 +27,13 @@ public abstract class AbstractEnumChapter<K extends Enum<K>, V> implements Chapt
     protected abstract String title(K key);
 
     @Override
+    public V get(K key) {
+        return chapter.getOrDefault(key, getDefault());
+    }
+
+    protected abstract V getDefault();
+
+    @Override
     public void addAll(EnumMap<K, V> items) {
         this.chapter.putAll(Objects.requireNonNull(items));
     }

--- a/src/ru/javawebinar/basejava/model/chapters/Contacts.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Contacts.java
@@ -1,0 +1,6 @@
+package ru.javawebinar.basejava.model.chapters;
+
+import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+
+public class Contacts extends AbstractEnumChapter<ContactType, String> {
+}

--- a/src/ru/javawebinar/basejava/model/chapters/Contacts.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Contacts.java
@@ -18,4 +18,9 @@ public class Contacts extends AbstractEnumChapter<ContactType, String> {
     protected String title(ContactType key) {
         return key.getTitle();
     }
+
+    @Override
+    protected String getDefault() {
+        return "";
+    }
 }

--- a/src/ru/javawebinar/basejava/model/chapters/Contacts.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Contacts.java
@@ -2,5 +2,20 @@ package ru.javawebinar.basejava.model.chapters;
 
 import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
 
+import java.util.EnumMap;
+
+/**
+ * The class is EnumMap type chapter of Resume to store person's contacts.
+ * Search key type - ContactType.
+ * Data type - String.
+ */
 public class Contacts extends AbstractEnumChapter<ContactType, String> {
+    public Contacts() {
+        super(new EnumMap<>(ContactType.class));
+    }
+
+    @Override
+    protected String title(ContactType key) {
+        return key.getTitle();
+    }
 }

--- a/src/ru/javawebinar/basejava/model/chapters/Sections.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Sections.java
@@ -1,0 +1,7 @@
+package ru.javawebinar.basejava.model.chapters;
+
+import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
+import ru.javawebinar.basejava.model.interfaces.Section;
+
+public class Sections extends AbstractEnumChapter<SectionType, Section> {
+}

--- a/src/ru/javawebinar/basejava/model/chapters/Sections.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Sections.java
@@ -3,5 +3,20 @@ package ru.javawebinar.basejava.model.chapters;
 import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
 import ru.javawebinar.basejava.model.interfaces.Section;
 
+import java.util.EnumMap;
+/**
+ * The class is EnumMap type chapter of Resume to store different sections with information about person.
+ * Search key type - SectionType.
+ * Data type - Section.
+ */
+
 public class Sections extends AbstractEnumChapter<SectionType, Section> {
+    public Sections() {
+        super(new EnumMap<>(SectionType.class));
+    }
+
+    @Override
+    protected String title(SectionType key) {
+        return key.getTitle();
+    }
 }

--- a/src/ru/javawebinar/basejava/model/chapters/Sections.java
+++ b/src/ru/javawebinar/basejava/model/chapters/Sections.java
@@ -2,6 +2,7 @@ package ru.javawebinar.basejava.model.chapters;
 
 import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
 import ru.javawebinar.basejava.model.interfaces.Section;
+import ru.javawebinar.basejava.model.sections.TextSection;
 
 import java.util.EnumMap;
 /**
@@ -18,5 +19,10 @@ public class Sections extends AbstractEnumChapter<SectionType, Section> {
     @Override
     protected String title(SectionType key) {
         return key.getTitle();
+    }
+
+    @Override
+    protected Section getDefault() {
+        return new TextSection("");
     }
 }

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/ContactType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/ContactType.java
@@ -1,4 +1,23 @@
 package ru.javawebinar.basejava.model.enumKeyTypes;
 
-public enum ContactType {
+import ru.javawebinar.basejava.model.interfaces.KeyType;
+
+public enum ContactType implements KeyType {
+    TEL("Тел.:"),
+    SKYPE("Skype:"),
+    MAIL("Почта:"),
+    LINKEDIN("Профиль Linkedin"),
+    GITHUB("Профиль GitHub"),
+    STACKOVERFLOW("Профиль Stackoverflow"),
+    HOMEPAGE("Домашняя страница");
+
+    private final String title;
+
+    ContactType(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/ContactType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/ContactType.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.enumKeyTypes;
+
+public enum ContactType {
+}

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/HeaderType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/HeaderType.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.enumKeyTypes;
+
+public enum HeaderType {
+}

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/HeaderType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/HeaderType.java
@@ -1,4 +1,19 @@
 package ru.javawebinar.basejava.model.enumKeyTypes;
 
-public enum HeaderType {
+import ru.javawebinar.basejava.model.interfaces.KeyType;
+
+public enum HeaderType implements KeyType {
+    TITLE("Название"),
+    LINK("Ссылка");
+
+    private final String title;
+
+    HeaderType(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/InfoType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/InfoType.java
@@ -1,4 +1,21 @@
 package ru.javawebinar.basejava.model.enumKeyTypes;
 
-public enum InfoType {
+import ru.javawebinar.basejava.model.interfaces.KeyType;
+
+public enum InfoType implements KeyType {
+    START("Начало, ММ/ГГГГ"),
+    END("Окончание, ММ/ГГГГ"),
+    HEADER("Заголовок"),
+    DESCRIPTION("Описание");
+
+    private final String title;
+
+    InfoType(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/InfoType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/InfoType.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.enumKeyTypes;
+
+public enum InfoType {
+}

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/SectionType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/SectionType.java
@@ -1,4 +1,23 @@
 package ru.javawebinar.basejava.model.enumKeyTypes;
 
-public enum SectionType {
+import ru.javawebinar.basejava.model.interfaces.KeyType;
+
+public enum SectionType implements KeyType {
+    PERSONAL("Личные качества"),
+    OBJECTIVE("Позиция"),
+    ACHIEVEMENT("Достижения"),
+    QUALIFICATIONS("Квалификация"),
+    EXPERIENCE("Опыт работы"),
+    EDUCATION("Образование");
+
+    private final String title;
+
+    SectionType(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/enumKeyTypes/SectionType.java
+++ b/src/ru/javawebinar/basejava/model/enumKeyTypes/SectionType.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.enumKeyTypes;
+
+public enum SectionType {
+}

--- a/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
@@ -7,7 +7,7 @@ import java.util.Set;
 public interface Chapter<K extends Enum<K>, V> {
     String getTitle(K key);
 
-    void addAll(EnumMap<K, V> items);
+    void save(EnumMap<K, V> items);
 
     V get(K key);
     Set<Map.Entry<K, V>> getAll();

--- a/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.interfaces;
+
+public interface Chapter <K extends Enum<K>, V> {
+}

--- a/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
@@ -9,5 +9,6 @@ public interface Chapter<K extends Enum<K>, V> {
 
     void addAll(EnumMap<K, V> items);
 
+    V get(K key);
     Set<Map.Entry<K, V>> getAll();
 }

--- a/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Chapter.java
@@ -1,4 +1,13 @@
 package ru.javawebinar.basejava.model.interfaces;
 
-public interface Chapter <K extends Enum<K>, V> {
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+public interface Chapter<K extends Enum<K>, V> {
+    String getTitle(K key);
+
+    void addAll(EnumMap<K, V> items);
+
+    Set<Map.Entry<K, V>> getAll();
 }

--- a/src/ru/javawebinar/basejava/model/interfaces/KeyType.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/KeyType.java
@@ -1,4 +1,5 @@
 package ru.javawebinar.basejava.model.interfaces;
 
 public interface KeyType {
+    String getTitle();
 }

--- a/src/ru/javawebinar/basejava/model/interfaces/KeyType.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/KeyType.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.interfaces;
+
+public interface KeyType {
+}

--- a/src/ru/javawebinar/basejava/model/interfaces/Section.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Section.java
@@ -1,4 +1,5 @@
 package ru.javawebinar.basejava.model.interfaces;
 
-public interface Section <T>{
+public interface Section<T> {
+    T getContent();
 }

--- a/src/ru/javawebinar/basejava/model/interfaces/Section.java
+++ b/src/ru/javawebinar/basejava/model/interfaces/Section.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.interfaces;
+
+public interface Section <T>{
+}

--- a/src/ru/javawebinar/basejava/model/item/Header.java
+++ b/src/ru/javawebinar/basejava/model/item/Header.java
@@ -3,5 +3,20 @@ package ru.javawebinar.basejava.model.item;
 import ru.javawebinar.basejava.model.chapters.AbstractEnumChapter;
 import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
 
+import java.util.EnumMap;
+
+/**
+ * The class is EnumMap type chapter of Item to store title of organization and link on it.
+ * Search key type - HeaderType.
+ * Data type - String.
+ */
 public class Header extends AbstractEnumChapter<HeaderType, String> {
+    public Header() {
+        super(new EnumMap<>(HeaderType.class));
+    }
+
+    @Override
+    protected String title(HeaderType key) {
+        return key.getTitle();
+    }
 }

--- a/src/ru/javawebinar/basejava/model/item/Header.java
+++ b/src/ru/javawebinar/basejava/model/item/Header.java
@@ -1,0 +1,7 @@
+package ru.javawebinar.basejava.model.item;
+
+import ru.javawebinar.basejava.model.chapters.AbstractEnumChapter;
+import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+
+public class Header extends AbstractEnumChapter<HeaderType, String> {
+}

--- a/src/ru/javawebinar/basejava/model/item/Header.java
+++ b/src/ru/javawebinar/basejava/model/item/Header.java
@@ -19,4 +19,9 @@ public class Header extends AbstractEnumChapter<HeaderType, String> {
     protected String title(HeaderType key) {
         return key.getTitle();
     }
+
+    @Override
+    protected String getDefault() {
+        return "";
+    }
 }

--- a/src/ru/javawebinar/basejava/model/item/Info.java
+++ b/src/ru/javawebinar/basejava/model/item/Info.java
@@ -3,5 +3,21 @@ package ru.javawebinar.basejava.model.item;
 import ru.javawebinar.basejava.model.chapters.AbstractEnumChapter;
 import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
 
+import java.util.EnumMap;
+
+/**
+ * The class is EnumMap type chapter that represent an element in the List<Info> field of Item
+ * to store block of information about person's period of study or work in a particular organization.
+ * Search key type - InfoType.
+ * Data type - String.
+ */
 public class Info extends AbstractEnumChapter<InfoType, String> {
+    public Info() {
+        super(new EnumMap<>(InfoType.class));
+    }
+
+    @Override
+    protected String title(InfoType key) {
+        return key.getTitle();
+    }
 }

--- a/src/ru/javawebinar/basejava/model/item/Info.java
+++ b/src/ru/javawebinar/basejava/model/item/Info.java
@@ -1,0 +1,7 @@
+package ru.javawebinar.basejava.model.item;
+
+import ru.javawebinar.basejava.model.chapters.AbstractEnumChapter;
+import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
+
+public class Info extends AbstractEnumChapter<InfoType, String> {
+}

--- a/src/ru/javawebinar/basejava/model/item/Info.java
+++ b/src/ru/javawebinar/basejava/model/item/Info.java
@@ -6,7 +6,7 @@ import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
 import java.util.EnumMap;
 
 /**
- * The class is EnumMap type chapter that represent an element in the List<Info> field of Item
+ * The class is EnumMap type chapter that represent an element in the ListInfoSection field of Item
  * to store block of information about person's period of study or work in a particular organization.
  * Search key type - InfoType.
  * Data type - String.

--- a/src/ru/javawebinar/basejava/model/item/Info.java
+++ b/src/ru/javawebinar/basejava/model/item/Info.java
@@ -20,4 +20,9 @@ public class Info extends AbstractEnumChapter<InfoType, String> {
     protected String title(InfoType key) {
         return key.getTitle();
     }
+
+    @Override
+    protected String getDefault() {
+        return "";
+    }
 }

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -1,9 +1,15 @@
 package ru.javawebinar.basejava.model.item;
 
+import ru.javawebinar.basejava.model.chapters.AbstractEnumChapter;
 import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
 import ru.javawebinar.basejava.model.sections.ListInfoSection;
 
-import java.util.*;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.counting;
 
 /**
  * The class to store information about an organisation in a person's career.
@@ -26,6 +32,7 @@ public class Item {
     public Header getHeader() {
         return header;
     }
+
     /**
      * @return unmodifiable List.
      * Attempting to modify will result in an UnsupportedOperationException in runtime.
@@ -42,9 +49,11 @@ public class Item {
         Item item = (Item) o;
 
         if (!header.equals(item.header)) return false;
-        if (getInfo().size() != ((Item) o).getInfo().size()) return false;
+        List<Info> that = item.getInfo();
+        if (info.getContent().size() != that.size()) return false;
 
-        return info.equals(item.info);
+        return Objects.equals(getInfo().stream().collect(Collectors.groupingBy(AbstractEnumChapter::getAll, counting())),
+                that.stream().collect(Collectors.groupingBy(AbstractEnumChapter::getAll, counting())));
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -1,4 +1,60 @@
 package ru.javawebinar.basejava.model.item;
 
+import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The class to store information about an organisation in a person's career.
+ */
 public class Item {
+    private final Header header;
+    private final List<Info> informationBlocks;
+
+    public Item(EnumMap<HeaderType, String> header, List<Info> info) {
+        this.header = new Header() {{
+            addAll(Objects.requireNonNull(header));
+        }};
+        informationBlocks = new ArrayList<>(Objects.requireNonNull(info));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public List<Info> getInfo() {
+        return List.copyOf(informationBlocks);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Item item = (Item) o;
+
+        if (!header.equals(item.header)) return false;
+        return informationBlocks.equals(item.informationBlocks);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = header.hashCode();
+        result = 31 * result + informationBlocks.hashCode();
+        return result;
+    }
+
+    private String toStringListInfo() {
+        StringBuilder info = new StringBuilder();
+        informationBlocks.forEach(i -> info.append(i).append("\n"));
+        return info.toString();
+    }
+
+    @Override
+    public String toString() {
+        return header + toStringListInfo();
+    }
 }

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -1,32 +1,37 @@
 package ru.javawebinar.basejava.model.item;
 
 import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+import ru.javawebinar.basejava.model.sections.ListInfoSection;
 
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * The class to store information about an organisation in a person's career.
  */
 public class Item {
     private final Header header;
-    private final List<Info> informationBlocks;
+    private final ListInfoSection info;
 
     public Item(EnumMap<HeaderType, String> header, List<Info> info) {
         this.header = new Header() {{
             addAll(Objects.requireNonNull(header));
         }};
-        informationBlocks = new ArrayList<>(Objects.requireNonNull(info));
+        this.info = new ListInfoSection(info);
     }
 
-    public Header getHeader() {
-        return header;
+    /**
+     * @return Collections.unmodifiableSet.
+     * Attempting to modify will result in an UnsupportedOperationException in runtime.
+     */
+    public Set<Map.Entry<HeaderType, String>> getHeader() {
+        return header.getAll();
     }
-
+    /**
+     * @return unmodifiable List.
+     * Attempting to modify will result in an UnsupportedOperationException in runtime.
+     */
     public List<Info> getInfo() {
-        return List.copyOf(informationBlocks);
+        return info.getContent();
     }
 
     @Override
@@ -37,24 +42,18 @@ public class Item {
         Item item = (Item) o;
 
         if (!header.equals(item.header)) return false;
-        return informationBlocks.equals(item.informationBlocks);
+        return info.equals(item.info);
     }
 
     @Override
     public int hashCode() {
         int result = header.hashCode();
-        result = 31 * result + informationBlocks.hashCode();
+        result = 31 * result + info.hashCode();
         return result;
-    }
-
-    private String toStringListInfo() {
-        StringBuilder info = new StringBuilder();
-        informationBlocks.forEach(i -> info.append(i).append("\n"));
-        return info.toString();
     }
 
     @Override
     public String toString() {
-        return header + toStringListInfo();
+        return header + info.toString();
     }
 }

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.item;
+
+public class Item {
+}

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -23,8 +23,8 @@ public class Item {
      * @return Collections.unmodifiableSet.
      * Attempting to modify will result in an UnsupportedOperationException in runtime.
      */
-    public Set<Map.Entry<HeaderType, String>> getHeader() {
-        return header.getAll();
+    public Header getHeader() {
+        return header;
     }
     /**
      * @return unmodifiable List.

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -42,6 +42,8 @@ public class Item {
         Item item = (Item) o;
 
         if (!header.equals(item.header)) return false;
+        if (getInfo().size() != ((Item) o).getInfo().size()) return false;
+
         return info.equals(item.info);
     }
 

--- a/src/ru/javawebinar/basejava/model/item/Item.java
+++ b/src/ru/javawebinar/basejava/model/item/Item.java
@@ -14,7 +14,7 @@ public class Item {
 
     public Item(EnumMap<HeaderType, String> header, List<Info> info) {
         this.header = new Header() {{
-            addAll(Objects.requireNonNull(header));
+            save(Objects.requireNonNull(header));
         }};
         this.info = new ListInfoSection(info);
     }

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -33,8 +33,8 @@ public abstract class AbstractListSection<T> implements Section<List<T>> {
 
         List<?> that = ((AbstractListSection<?>) o).getContent();
 
-        return Objects.equals(content.stream().collect(groupingBy(T::hashCode, counting())),
-                that.stream().collect(groupingBy(Object::hashCode, counting())));
+        return Objects.equals(content.stream().collect(groupingBy(key -> key, counting())),
+                that.stream().collect(groupingBy(key -> key, counting())));
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -34,6 +34,7 @@ public abstract class AbstractListSection<T> implements Section<List<T>> {
         if (o == null || getClass() != o.getClass()) return false;
 
         List<?> that = ((AbstractListSection<?>) o).getContent();
+        if (content.size() != that.size()) return false;
 
         return Objects.equals(content.stream().collect(groupingBy(key -> key, counting())),
                 that.stream().collect(groupingBy(key -> key, counting())));

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -1,0 +1,8 @@
+package ru.javawebinar.basejava.model.sections;
+
+import ru.javawebinar.basejava.model.interfaces.Section;
+
+import java.util.List;
+
+public class AbstractListSection<T> implements Section<List<T>> {
+}

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -2,7 +2,6 @@ package ru.javawebinar.basejava.model.sections;
 
 import ru.javawebinar.basejava.model.interfaces.Section;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -12,18 +11,21 @@ import static java.util.stream.Collectors.groupingBy;
 /**
  * Base class for all types of section which contains List as content.
  *
- * @param <T> any reference data type of section. For custom class hashcode() must be override.
+ * @param <T> any reference data type. For custom class T equals and hashcode() must be override.
  */
 public abstract class AbstractListSection<T> implements Section<List<T>> {
     private final List<T> content;
 
     protected AbstractListSection(List<T> content) {
-        this.content = new ArrayList<>(Objects.requireNonNull(content));
+        this.content = checkContent(content);
     }
 
+    private List<T> checkContent(List<T> content) {
+        return Objects.requireNonNull(content).stream().filter(Objects::nonNull).toList();
+    }
     @Override
     public List<T> getContent() {
-        return List.copyOf(content);
+        return content;
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -6,10 +6,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
 /**
  * Base class for all types of section which contains List as content.
  *
- * @param <T> any reference data type of section.
+ * @param <T> any reference data type of section. For custom class hashcode() must be override.
  */
 public class AbstractListSection<T> implements Section<List<T>> {
     private final List<T> content;
@@ -28,9 +31,10 @@ public class AbstractListSection<T> implements Section<List<T>> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        AbstractListSection<?> that = (AbstractListSection<?>) o;
+        List<?> that = ((AbstractListSection<?>) o).getContent();
 
-        return content.equals(that.content);
+        return Objects.equals(content.stream().collect(groupingBy(T::hashCode, counting())),
+                that.stream().collect(groupingBy(Object::hashCode, counting())));
     }
 
     @Override

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -2,11 +2,46 @@ package ru.javawebinar.basejava.model.sections;
 
 import ru.javawebinar.basejava.model.interfaces.Section;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+/**
+ * Base class for all types of section which contains List as content.
+ *
+ * @param <T> any reference data type of section.
+ */
 public class AbstractListSection<T> implements Section<List<T>> {
+    private final List<T> content;
+
+    protected AbstractListSection(List<T> content) {
+        this.content = new ArrayList<>(Objects.requireNonNull(content));
+    }
+
     @Override
     public List<T> getContent() {
-        return null;
+        return List.copyOf(content);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractListSection<?> that = (AbstractListSection<?>) o;
+
+        return content.equals(that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return content.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        content.forEach(T -> result.append(T.toString()).append("\n"));
+        return result.toString();
     }
 }

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -5,4 +5,8 @@ import ru.javawebinar.basejava.model.interfaces.Section;
 import java.util.List;
 
 public class AbstractListSection<T> implements Section<List<T>> {
+    @Override
+    public List<T> getContent() {
+        return null;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/AbstractListSection.java
@@ -14,7 +14,7 @@ import static java.util.stream.Collectors.groupingBy;
  *
  * @param <T> any reference data type of section. For custom class hashcode() must be override.
  */
-public class AbstractListSection<T> implements Section<List<T>> {
+public abstract class AbstractListSection<T> implements Section<List<T>> {
     private final List<T> content;
 
     protected AbstractListSection(List<T> content) {

--- a/src/ru/javawebinar/basejava/model/sections/ListInfoSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/ListInfoSection.java
@@ -1,0 +1,11 @@
+package ru.javawebinar.basejava.model.sections;
+
+import ru.javawebinar.basejava.model.item.Info;
+
+import java.util.List;
+
+public class ListInfoSection extends AbstractListSection<Info> {
+    public ListInfoSection(List<Info> content) {
+        super(content);
+    }
+}

--- a/src/ru/javawebinar/basejava/model/sections/ListItemSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/ListItemSection.java
@@ -2,5 +2,13 @@ package ru.javawebinar.basejava.model.sections;
 
 import ru.javawebinar.basejava.model.item.Item;
 
+import java.util.List;
+
+/**
+ * The class to store List of Items.
+ */
 public class ListItemSection extends AbstractListSection<Item> {
+    public ListItemSection(List<Item> content) {
+        super(content);
+    }
 }

--- a/src/ru/javawebinar/basejava/model/sections/ListItemSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/ListItemSection.java
@@ -1,0 +1,6 @@
+package ru.javawebinar.basejava.model.sections;
+
+import ru.javawebinar.basejava.model.item.Item;
+
+public class ListItemSection extends AbstractListSection<Item> {
+}

--- a/src/ru/javawebinar/basejava/model/sections/ListStringSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/ListStringSection.java
@@ -1,4 +1,12 @@
 package ru.javawebinar.basejava.model.sections;
 
+import java.util.List;
+
+/**
+ * The class to store List of strings.
+ */
 public class ListStringSection extends AbstractListSection<String> {
+    public ListStringSection(List<String> content) {
+        super(content);
+    }
 }

--- a/src/ru/javawebinar/basejava/model/sections/ListStringSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/ListStringSection.java
@@ -1,0 +1,4 @@
+package ru.javawebinar.basejava.model.sections;
+
+public class ListStringSection extends AbstractListSection<String> {
+}

--- a/src/ru/javawebinar/basejava/model/sections/TextSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/TextSection.java
@@ -3,4 +3,8 @@ package ru.javawebinar.basejava.model.sections;
 import ru.javawebinar.basejava.model.interfaces.Section;
 
 public class TextSection implements Section<String> {
+    @Override
+    public String getContent() {
+        return null;
+    }
 }

--- a/src/ru/javawebinar/basejava/model/sections/TextSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/TextSection.java
@@ -2,9 +2,39 @@ package ru.javawebinar.basejava.model.sections;
 
 import ru.javawebinar.basejava.model.interfaces.Section;
 
+import java.util.Objects;
+
+/**
+ * The class to store simple text.
+ */
 public class TextSection implements Section<String> {
+    private final String text;
+
+    public TextSection(String text) {
+        this.text = Objects.requireNonNull(text);
+    }
+
     @Override
     public String getContent() {
-        return null;
+        return text;
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TextSection that = (TextSection) o;
+
+        return text.equals(that.text);
+    }
+
+    @Override
+    public int hashCode() {
+        return text.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return text + "\n";
     }
 }

--- a/src/ru/javawebinar/basejava/model/sections/TextSection.java
+++ b/src/ru/javawebinar/basejava/model/sections/TextSection.java
@@ -1,0 +1,6 @@
+package ru.javawebinar.basejava.model.sections;
+
+import ru.javawebinar.basejava.model.interfaces.Section;
+
+public class TextSection implements Section<String> {
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -15,6 +15,7 @@ import ru.javawebinar.basejava.model.sections.ListStringSection;
 import ru.javawebinar.basejava.model.sections.TextSection;
 import ru.javawebinar.basejava.modelDataTest.creators.ContactsCreator;
 import ru.javawebinar.basejava.modelDataTest.creators.SectionsCreator;
+import ru.javawebinar.basejava.modelDataTest.testData.Qualifications;
 
 import java.util.*;
 
@@ -42,6 +43,7 @@ public class ResumeTestData {
         checkUnmodifiableSections();
         checkItemsExtractedCorrectly();
         checkUnmodifiableChapterOfResumeWithAddAllChaptersMethod();
+        checkRemoveNullFromConstructorParameterListSection();
     }
 
     private void doTest(Boolean assertion, String message) {
@@ -189,5 +191,16 @@ public class ResumeTestData {
             return;
         }
         doTest(false, ResumeTestData.class.getDeclaredMethods()[11].getName());
+    }
+
+    public void checkRemoveNullFromConstructorParameterListSection() {
+        List<String> qualifications = new ArrayList<>() {{
+            add("JEE AS: GlassFish (v2.1, v3), OC4J, JBoss, Tomcat, Jetty, WebLogic, WSO2");
+            add("Version control: Subversion, Git, Mercury, ClearCase, Perforce");
+            add(null);
+        }};
+        ListStringSection result = new ListStringSection(qualifications);
+        ListStringSection expected = Qualifications.createSection();
+        doTest(Objects.equals(expected, result), ResumeTestData.class.getDeclaredMethods()[12].getName());
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -1,0 +1,119 @@
+package ru.javawebinar.basejava.modelDataTest;
+
+import ru.javawebinar.basejava.model.Resume;
+import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
+import ru.javawebinar.basejava.model.interfaces.Section;
+import ru.javawebinar.basejava.model.sections.ListStringSection;
+import ru.javawebinar.basejava.model.sections.TextSection;
+import ru.javawebinar.basejava.modelDataTest.creators.ContactsCreator;
+import ru.javawebinar.basejava.modelDataTest.creators.SectionsCreator;
+
+import java.util.*;
+
+import static ru.javawebinar.basejava.model.enumKeyTypes.SectionType.*;
+import static ru.javawebinar.basejava.modelDataTest.creators.ResumeCreator.createResume;
+
+public class ResumeTestData {
+    public static void main(String[] args) {
+        new ResumeTestData().run();
+    }
+
+    public void run() {
+        checkContactsAddedCorrectly();
+        checkSectionsAddedCorrectly();
+        checkContactsExtractedCorrectly();
+        checkSectionsExtractedCorrectly();
+        checkThrowWhenTryToModifySectionsContent();
+        checkThrowWhenTryToModifyListSectionContent();
+        checkUnmodifiableContacts();
+        checkUnmodifiableSections();
+    }
+
+    private void doTest(Boolean assertion, String message) {
+        if (assertion) {
+            System.out.printf("TEST: %s - SUCCESS\n", message);
+        } else {
+            System.out.printf("TEST: %s - FAIL\n", message);
+        }
+    }
+
+    public void checkContactsAddedCorrectly() {
+        doTest(Objects.equals(
+                ContactsCreator.create(), createResume().getContacts()), ResumeTestData.class.getDeclaredMethods()[0].getName()
+        );
+    }
+
+    public void checkSectionsAddedCorrectly() {
+        doTest(Objects.equals(
+                SectionsCreator.create(), createResume().getSections()), ResumeTestData.class.getDeclaredMethods()[1].getName()
+        );
+    }
+
+    public void checkContactsExtractedCorrectly() {
+        Resume resume = createResume();
+        EnumMap<ContactType, String> extracted = new EnumMap<>(ContactType.class) {{
+            resume.getContacts().forEach(contact -> this.put(contact.getKey(), contact.getValue()));
+        }};
+        doTest(Objects.equals(
+                extracted.entrySet(), resume.getContacts()), ResumeTestData.class.getDeclaredMethods()[2].getName());
+    }
+
+    public void checkSectionsExtractedCorrectly() {
+        Resume resume = createResume();
+        EnumMap<SectionType, Section> extracted = new EnumMap<>(SectionType.class) {{
+            resume.getSections().forEach(section -> this.put(section.getKey(), section.getValue()));
+        }};
+        doTest(Objects.equals(
+                extracted.entrySet(), resume.getSections()), ResumeTestData.class.getDeclaredMethods()[3].getName());
+    }
+
+    public void checkThrowWhenTryToModifySectionsContent() {
+        Set<Map.Entry<SectionType, Section>> sections = createResume().getSections();
+        try {
+            sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection()));
+            sections.clear();
+        } catch (UnsupportedOperationException e) {
+            doTest(Objects.equals(createResume().getSections(), sections), ResumeTestData.class.getDeclaredMethods()[4].getName() + " " + e);
+            return;
+        }
+        doTest(false, ResumeTestData.class.getDeclaredMethods()[4].getName());
+    }
+
+    public void checkThrowWhenTryToModifyListSectionContent() {
+        Set<Map.Entry<SectionType, Section>> sections = createResume().getSections();
+        for (Map.Entry<SectionType, Section> section : sections) {
+            if (section.getKey().equals(ACHIEVEMENT)) {
+                ListStringSection achievement = (ListStringSection) section.getValue();
+                List<String> content = achievement.getContent();
+                try {
+                    content.add("CHANGE!");
+                } catch (UnsupportedOperationException e) {
+                    doTest(Objects.equals(
+                            createResume().getSections(), sections), ResumeTestData.class.getDeclaredMethods()[5].getName() + " " + e
+                    );
+                    return;
+                }
+                doTest(false, ResumeTestData.class.getDeclaredMethods()[5].getName());
+            }
+        }
+    }
+
+    public void checkUnmodifiableContacts() {
+        Resume resume = createResume();
+        for (Map.Entry<ContactType, String> contact : resume.getContacts()) {
+            contact.setValue("NEW");
+        }
+        Set<Map.Entry<ContactType, String>> after = resume.getContacts();
+        doTest(Objects.equals(createResume().getContacts(), after), ResumeTestData.class.getDeclaredMethods()[6].getName());
+    }
+
+    public void checkUnmodifiableSections() {
+        Resume resume = createResume();
+        for (Map.Entry<SectionType, Section> section : resume.getSections()) {
+            section.setValue(new TextSection());
+        }
+        Set<Map.Entry<SectionType, Section>> after = resume.getSections();
+        doTest(Objects.equals(createResume().getSections(), after), ResumeTestData.class.getDeclaredMethods()[7].getName());
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -1,6 +1,7 @@
 package ru.javawebinar.basejava.modelDataTest;
 
 import ru.javawebinar.basejava.model.Resume;
+import ru.javawebinar.basejava.model.chapters.Contacts;
 import ru.javawebinar.basejava.model.chapters.Sections;
 import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
 import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
@@ -35,8 +36,8 @@ public class ResumeTestData {
         checkSectionsAddedCorrectly();
         checkContactsExtractedCorrectly();
         checkSectionsExtractedCorrectly();
-        checkThrowWhenTryToModifySectionsContent();
-        checkThrowWhenTryToModifyListSectionContent();
+        checkUnmodifiableSectionContent();
+        checkUnmodifiableListSectionContent();
         checkUnmodifiableContacts();
         checkUnmodifiableSections();
         checkItemsExtractedCorrectly();
@@ -87,7 +88,7 @@ public class ResumeTestData {
         );
     }
 
-    public void checkThrowWhenTryToModifySectionsContent() {
+    public void checkUnmodifiableSectionContent() {
         Set<Map.Entry<SectionType, Section>> sections = createResume().getSections().getAll();
         try {
             sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection("NEW")));
@@ -101,14 +102,14 @@ public class ResumeTestData {
         doTest(false, ResumeTestData.class.getDeclaredMethods()[6].getName());
     }
 
-    public void checkThrowWhenTryToModifyListSectionContent() {
-        Resume resume = createResume();
-        ListStringSection ach = (ListStringSection) resume.getSections().get(ACHIEVEMENT);
+    public void checkUnmodifiableListSectionContent() {
+        ListStringSection achievement = (ListStringSection) createResume().getSections().get(ACHIEVEMENT);
         try {
-            ach.getContent().add("CHANGE!");
+            achievement.getContent().add("CHANGE!");
         } catch (UnsupportedOperationException e) {
-            doTest(Objects.equals(
-                    createResume().getSections(), resume.getSections()), ResumeTestData.class.getDeclaredMethods()[7].getName() + " " + e
+            doTest(
+                    Objects.equals(createResume().getSections().get(ACHIEVEMENT), achievement),
+                    ResumeTestData.class.getDeclaredMethods()[7].getName() + " " + e
             );
             return;
         }
@@ -117,13 +118,14 @@ public class ResumeTestData {
 
     public void checkUnmodifiableContacts() {
         Resume resume = createResume();
-        for (Map.Entry<ContactType, String> contact : resume.getContacts().getAll()) {
+        Contacts before = resume.getContacts();
+        for (Map.Entry<ContactType, String> contact : before.getAll()) {
             try {
                 contact.setValue("NEW");
             } catch (UnsupportedOperationException e) {
-                Set<Map.Entry<ContactType, String>> after = resume.getContacts().getAll();
+                Contacts after = resume.getContacts();
                 doTest(
-                        Objects.equals(createResume().getContacts().getAll(), after),
+                        Objects.equals(before, after),
                         ResumeTestData.class.getDeclaredMethods()[8].getName()
                 );
                 return;
@@ -134,13 +136,14 @@ public class ResumeTestData {
 
     public void checkUnmodifiableSections() {
         Resume resume = createResume();
-        for (Map.Entry<SectionType, Section> section : resume.getSections().getAll()) {
+        Sections before = resume.getSections();
+        for (Map.Entry<SectionType, Section> section : before.getAll()) {
             try {
                 section.setValue(new TextSection("NEW"));
             } catch (UnsupportedOperationException e) {
-                Set<Map.Entry<SectionType, Section>> after = resume.getSections().getAll();
+                Sections after = resume.getSections();
                 doTest(
-                        Objects.equals(createResume().getSections().getAll(), after),
+                        Objects.equals(before, after),
                         ResumeTestData.class.getDeclaredMethods()[9].getName()
                 );
                 return;
@@ -174,12 +177,13 @@ public class ResumeTestData {
 
     public void checkUnmodifiableChapterOfResumeWithAddAllChaptersMethod() {
         Resume resume = createResume();
+        Sections before = resume.getSections();
         try {
             resume.getSections().addAll(new EnumMap<>(SectionType.class));
         } catch (UnsupportedOperationException e) {
             Sections after = resume.getSections();
             doTest(
-                    Objects.equals(createResume().getSections(), after),
+                    Objects.equals(before, after),
                     ResumeTestData.class.getDeclaredMethods()[11].getName()
             );
             return;

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -165,7 +165,7 @@ public class ResumeTestData {
             item.getInfo().forEach(blockInfo -> {
                 blockInfo.getAll().forEach(entry -> info.put(entry.getKey(), entry.getValue()));
                 list.add(new Info() {{
-                    addAll(info);
+                    save(info);
                 }});
             });
             extracted.add(new Item(header, list));
@@ -179,7 +179,7 @@ public class ResumeTestData {
         Resume resume = createResume();
         Sections before = resume.getSections();
         try {
-            resume.getSections().addAll(new EnumMap<>(SectionType.class));
+            resume.getSections().save(new EnumMap<>(SectionType.class));
         } catch (UnsupportedOperationException e) {
             Sections after = resume.getSections();
             doTest(

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -45,106 +45,99 @@ public class ResumeTestData {
 
     public void checkContactsAddedCorrectly() {
         doTest(
-                Objects.equals(ContactsCreator.create(), createResume().getContacts()),
-                ResumeTestData.class.getDeclaredMethods()[0].getName()
+                Objects.equals(ContactsCreator.create(), createResume().getContacts().getAll()),
+                ResumeTestData.class.getDeclaredMethods()[2].getName()
         );
     }
 
     public void checkSectionsAddedCorrectly() {
         doTest(
-                Objects.equals(SectionsCreator.create(), createResume().getSections()),
-                ResumeTestData.class.getDeclaredMethods()[1].getName()
+                Objects.equals(SectionsCreator.create(), createResume().getSections().getAll()),
+                ResumeTestData.class.getDeclaredMethods()[3].getName()
         );
     }
 
     public void checkContactsExtractedCorrectly() {
         Resume resume = createResume();
         EnumMap<ContactType, String> extracted = new EnumMap<>(ContactType.class) {{
-            resume.getContacts().forEach(contact -> this.put(contact.getKey(), contact.getValue()));
+            resume.getContacts().getAll().forEach(contact -> this.put(contact.getKey(), contact.getValue()));
         }};
         doTest(
-                Objects.equals(extracted.entrySet(), resume.getContacts()),
-                ResumeTestData.class.getDeclaredMethods()[2].getName()
+                Objects.equals(extracted.entrySet(), resume.getContacts().getAll()),
+                ResumeTestData.class.getDeclaredMethods()[4].getName()
         );
     }
 
     public void checkSectionsExtractedCorrectly() {
         Resume resume = createResume();
         EnumMap<SectionType, Section> extracted = new EnumMap<>(SectionType.class) {{
-            resume.getSections().forEach(section -> this.put(section.getKey(), section.getValue()));
+            resume.getSections().getAll().forEach(section -> this.put(section.getKey(), section.getValue()));
         }};
         doTest(
-                Objects.equals(extracted.entrySet(), resume.getSections()),
-                ResumeTestData.class.getDeclaredMethods()[3].getName()
+                Objects.equals(extracted.entrySet(), resume.getSections().getAll()),
+                ResumeTestData.class.getDeclaredMethods()[5].getName()
         );
     }
 
     public void checkThrowWhenTryToModifySectionsContent() {
-        Set<Map.Entry<SectionType, Section>> sections = createResume().getSections();
+        Set<Map.Entry<SectionType, Section>> sections = createResume().getSections().getAll();
         try {
             sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection("NEW")));
-            sections.clear();
         } catch (UnsupportedOperationException e) {
             doTest(
-                    Objects.equals(createResume().getSections(), sections),
-                    ResumeTestData.class.getDeclaredMethods()[4].getName() + " " + e
+                    Objects.equals(createResume().getSections().getAll(), sections),
+                    ResumeTestData.class.getDeclaredMethods()[6].getName() + " " + e
             );
             return;
         }
-        doTest(false, ResumeTestData.class.getDeclaredMethods()[4].getName());
+        doTest(false, ResumeTestData.class.getDeclaredMethods()[6].getName());
     }
 
     public void checkThrowWhenTryToModifyListSectionContent() {
-        Set<Map.Entry<SectionType, Section>> sections = createResume().getSections();
-        for (Map.Entry<SectionType, Section> section : sections) {
-            if (section.getKey().equals(ACHIEVEMENT)) {
-                ListStringSection achievement = (ListStringSection) section.getValue();
-                List<String> content = achievement.getContent();
-                try {
-                    content.add("CHANGE!");
-                } catch (UnsupportedOperationException e) {
-                    doTest(
-                            Objects.equals(createResume().getSections(), sections),
-                            ResumeTestData.class.getDeclaredMethods()[5].getName() + " " + e
-                    );
-                    return;
-                }
-                doTest(false, ResumeTestData.class.getDeclaredMethods()[5].getName());
-            }
+        Resume resume = createResume();
+        ListStringSection ach = (ListStringSection) resume.getSections().get(ACHIEVEMENT);
+        try {
+            ach.getContent().add("CHANGE!");
+        } catch (UnsupportedOperationException e) {
+            doTest(Objects.equals(
+                    createResume().getSections(), resume.getSections()), ResumeTestData.class.getDeclaredMethods()[7].getName() + " " + e
+            );
+            return;
         }
+        doTest(false, ResumeTestData.class.getDeclaredMethods()[7].getName());
     }
 
     public void checkUnmodifiableContacts() {
         Resume resume = createResume();
-        for (Map.Entry<ContactType, String> contact : resume.getContacts()) {
+        for (Map.Entry<ContactType, String> contact : resume.getContacts().getAll()) {
             try {
                 contact.setValue("NEW");
             } catch (UnsupportedOperationException e) {
-                Set<Map.Entry<ContactType, String>> after = resume.getContacts();
+                Set<Map.Entry<ContactType, String>> after = resume.getContacts().getAll();
                 doTest(
-                        Objects.equals(createResume().getContacts(), after),
-                        ResumeTestData.class.getDeclaredMethods()[6].getName()
+                        Objects.equals(createResume().getContacts().getAll(), after),
+                        ResumeTestData.class.getDeclaredMethods()[8].getName()
                 );
                 return;
             }
-            doTest(false, ResumeTestData.class.getDeclaredMethods()[6].getName());
+            doTest(false, ResumeTestData.class.getDeclaredMethods()[8].getName());
         }
     }
 
     public void checkUnmodifiableSections() {
         Resume resume = createResume();
-        for (Map.Entry<SectionType, Section> section : resume.getSections()) {
+        for (Map.Entry<SectionType, Section> section : resume.getSections().getAll()) {
             try {
                 section.setValue(new TextSection("NEW"));
             } catch (UnsupportedOperationException e) {
-                Set<Map.Entry<SectionType, Section>> after = resume.getSections();
+                Set<Map.Entry<SectionType, Section>> after = resume.getSections().getAll();
                 doTest(
-                        Objects.equals(createResume().getSections(), after),
-                        ResumeTestData.class.getDeclaredMethods()[7].getName()
+                        Objects.equals(createResume().getSections().getAll(), after),
+                        ResumeTestData.class.getDeclaredMethods()[9].getName()
                 );
                 return;
             }
-            doTest(false, ResumeTestData.class.getDeclaredMethods()[7].getName());
+            doTest(false, ResumeTestData.class.getDeclaredMethods()[9].getName());
         }
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -117,24 +117,34 @@ public class ResumeTestData {
     public void checkUnmodifiableContacts() {
         Resume resume = createResume();
         for (Map.Entry<ContactType, String> contact : resume.getContacts()) {
-            contact.setValue("NEW");
+            try {
+                contact.setValue("NEW");
+            } catch (UnsupportedOperationException e) {
+                Set<Map.Entry<ContactType, String>> after = resume.getContacts();
+                doTest(
+                        Objects.equals(createResume().getContacts(), after),
+                        ResumeTestData.class.getDeclaredMethods()[6].getName()
+                );
+                return;
+            }
+            doTest(false, ResumeTestData.class.getDeclaredMethods()[6].getName());
         }
-        Set<Map.Entry<ContactType, String>> after = resume.getContacts();
-        doTest(
-                Objects.equals(createResume().getContacts(), after),
-                ResumeTestData.class.getDeclaredMethods()[6].getName()
-        );
     }
 
     public void checkUnmodifiableSections() {
         Resume resume = createResume();
         for (Map.Entry<SectionType, Section> section : resume.getSections()) {
-            section.setValue(new TextSection("NEW"));
+            try {
+                section.setValue(new TextSection("NEW"));
+            } catch (UnsupportedOperationException e) {
+                Set<Map.Entry<SectionType, Section>> after = resume.getSections();
+                doTest(
+                        Objects.equals(createResume().getSections(), after),
+                        ResumeTestData.class.getDeclaredMethods()[7].getName()
+                );
+                return;
+            }
+            doTest(false, ResumeTestData.class.getDeclaredMethods()[7].getName());
         }
-        Set<Map.Entry<SectionType, Section>> after = resume.getSections();
-        doTest(
-                Objects.equals(createResume().getSections(), after),
-                ResumeTestData.class.getDeclaredMethods()[7].getName()
-        );
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -1,6 +1,7 @@
 package ru.javawebinar.basejava.modelDataTest;
 
 import ru.javawebinar.basejava.model.Resume;
+import ru.javawebinar.basejava.model.chapters.Sections;
 import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
 import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
 import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
@@ -39,6 +40,7 @@ public class ResumeTestData {
         checkUnmodifiableContacts();
         checkUnmodifiableSections();
         checkItemsExtractedCorrectly();
+        checkUnmodifiableChapterOfResumeWithAddAllChaptersMethod();
     }
 
     private void doTest(Boolean assertion, String message) {
@@ -168,5 +170,20 @@ public class ResumeTestData {
         doTest(
                 Objects.equals(sours, extracted), ResumeTestData.class.getDeclaredMethods()[10].getName()
         );
+    }
+
+    public void checkUnmodifiableChapterOfResumeWithAddAllChaptersMethod() {
+        Resume resume = createResume();
+        try {
+            resume.getSections().addAll(new EnumMap<>(SectionType.class));
+        } catch (UnsupportedOperationException e) {
+            Sections after = resume.getSections();
+            doTest(
+                    Objects.equals(createResume().getSections(), after),
+                    ResumeTestData.class.getDeclaredMethods()[11].getName()
+            );
+            return;
+        }
+        doTest(false, ResumeTestData.class.getDeclaredMethods()[11].getName());
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -2,8 +2,13 @@ package ru.javawebinar.basejava.modelDataTest;
 
 import ru.javawebinar.basejava.model.Resume;
 import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
 import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
 import ru.javawebinar.basejava.model.interfaces.Section;
+import ru.javawebinar.basejava.model.item.Info;
+import ru.javawebinar.basejava.model.item.Item;
+import ru.javawebinar.basejava.model.sections.ListItemSection;
 import ru.javawebinar.basejava.model.sections.ListStringSection;
 import ru.javawebinar.basejava.model.sections.TextSection;
 import ru.javawebinar.basejava.modelDataTest.creators.ContactsCreator;
@@ -33,6 +38,7 @@ public class ResumeTestData {
         checkThrowWhenTryToModifyListSectionContent();
         checkUnmodifiableContacts();
         checkUnmodifiableSections();
+        checkItemsExtractedCorrectly();
     }
 
     private void doTest(Boolean assertion, String message) {
@@ -139,5 +145,28 @@ public class ResumeTestData {
             }
             doTest(false, ResumeTestData.class.getDeclaredMethods()[9].getName());
         }
+    }
+
+    public void checkItemsExtractedCorrectly() {
+        List<Item> sours = ((ListItemSection) createResume().getSections().get(EDUCATION)).getContent();
+        List<Item> extracted = new ArrayList<>();
+
+        sours.forEach(item -> {
+            EnumMap<HeaderType, String> header = new EnumMap<>(HeaderType.class);
+            item.getHeader().getAll().forEach(entry -> header.put(entry.getKey(), entry.getValue()));
+
+            List<Info> list = new ArrayList<>();
+            EnumMap<InfoType, String> info = new EnumMap<>(InfoType.class);
+            item.getInfo().forEach(blockInfo -> {
+                blockInfo.getAll().forEach(entry -> info.put(entry.getKey(), entry.getValue()));
+                list.add(new Info() {{
+                    addAll(info);
+                }});
+            });
+            extracted.add(new Item(header, list));
+        });
+        doTest(
+                Objects.equals(sours, extracted), ResumeTestData.class.getDeclaredMethods()[10].getName()
+        );
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -82,7 +82,7 @@ public class ResumeTestData {
     public void checkThrowWhenTryToModifySectionsContent() {
         Set<Map.Entry<SectionType, Section>> sections = createResume().getSections();
         try {
-            sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection()));
+            sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection("NEW")));
             sections.clear();
         } catch (UnsupportedOperationException e) {
             doTest(
@@ -129,7 +129,7 @@ public class ResumeTestData {
     public void checkUnmodifiableSections() {
         Resume resume = createResume();
         for (Map.Entry<SectionType, Section> section : resume.getSections()) {
-            section.setValue(new TextSection());
+            section.setValue(new TextSection("NEW"));
         }
         Set<Map.Entry<SectionType, Section>> after = resume.getSections();
         doTest(

--- a/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/ResumeTestData.java
@@ -16,10 +16,15 @@ import static ru.javawebinar.basejava.modelDataTest.creators.ResumeCreator.creat
 
 public class ResumeTestData {
     public static void main(String[] args) {
-        new ResumeTestData().run();
+        new ResumeTestData().runTests();
+        new ResumeTestData().printResume();
     }
 
-    public void run() {
+    public void printResume() {
+        System.out.println(createResume());
+    }
+
+    public void runTests() {
         checkContactsAddedCorrectly();
         checkSectionsAddedCorrectly();
         checkContactsExtractedCorrectly();
@@ -39,14 +44,16 @@ public class ResumeTestData {
     }
 
     public void checkContactsAddedCorrectly() {
-        doTest(Objects.equals(
-                ContactsCreator.create(), createResume().getContacts()), ResumeTestData.class.getDeclaredMethods()[0].getName()
+        doTest(
+                Objects.equals(ContactsCreator.create(), createResume().getContacts()),
+                ResumeTestData.class.getDeclaredMethods()[0].getName()
         );
     }
 
     public void checkSectionsAddedCorrectly() {
-        doTest(Objects.equals(
-                SectionsCreator.create(), createResume().getSections()), ResumeTestData.class.getDeclaredMethods()[1].getName()
+        doTest(
+                Objects.equals(SectionsCreator.create(), createResume().getSections()),
+                ResumeTestData.class.getDeclaredMethods()[1].getName()
         );
     }
 
@@ -55,8 +62,10 @@ public class ResumeTestData {
         EnumMap<ContactType, String> extracted = new EnumMap<>(ContactType.class) {{
             resume.getContacts().forEach(contact -> this.put(contact.getKey(), contact.getValue()));
         }};
-        doTest(Objects.equals(
-                extracted.entrySet(), resume.getContacts()), ResumeTestData.class.getDeclaredMethods()[2].getName());
+        doTest(
+                Objects.equals(extracted.entrySet(), resume.getContacts()),
+                ResumeTestData.class.getDeclaredMethods()[2].getName()
+        );
     }
 
     public void checkSectionsExtractedCorrectly() {
@@ -64,8 +73,10 @@ public class ResumeTestData {
         EnumMap<SectionType, Section> extracted = new EnumMap<>(SectionType.class) {{
             resume.getSections().forEach(section -> this.put(section.getKey(), section.getValue()));
         }};
-        doTest(Objects.equals(
-                extracted.entrySet(), resume.getSections()), ResumeTestData.class.getDeclaredMethods()[3].getName());
+        doTest(
+                Objects.equals(extracted.entrySet(), resume.getSections()),
+                ResumeTestData.class.getDeclaredMethods()[3].getName()
+        );
     }
 
     public void checkThrowWhenTryToModifySectionsContent() {
@@ -74,7 +85,10 @@ public class ResumeTestData {
             sections.add(new AbstractMap.SimpleEntry<>(PERSONAL, new TextSection()));
             sections.clear();
         } catch (UnsupportedOperationException e) {
-            doTest(Objects.equals(createResume().getSections(), sections), ResumeTestData.class.getDeclaredMethods()[4].getName() + " " + e);
+            doTest(
+                    Objects.equals(createResume().getSections(), sections),
+                    ResumeTestData.class.getDeclaredMethods()[4].getName() + " " + e
+            );
             return;
         }
         doTest(false, ResumeTestData.class.getDeclaredMethods()[4].getName());
@@ -89,8 +103,9 @@ public class ResumeTestData {
                 try {
                     content.add("CHANGE!");
                 } catch (UnsupportedOperationException e) {
-                    doTest(Objects.equals(
-                            createResume().getSections(), sections), ResumeTestData.class.getDeclaredMethods()[5].getName() + " " + e
+                    doTest(
+                            Objects.equals(createResume().getSections(), sections),
+                            ResumeTestData.class.getDeclaredMethods()[5].getName() + " " + e
                     );
                     return;
                 }
@@ -105,7 +120,10 @@ public class ResumeTestData {
             contact.setValue("NEW");
         }
         Set<Map.Entry<ContactType, String>> after = resume.getContacts();
-        doTest(Objects.equals(createResume().getContacts(), after), ResumeTestData.class.getDeclaredMethods()[6].getName());
+        doTest(
+                Objects.equals(createResume().getContacts(), after),
+                ResumeTestData.class.getDeclaredMethods()[6].getName()
+        );
     }
 
     public void checkUnmodifiableSections() {
@@ -114,6 +132,9 @@ public class ResumeTestData {
             section.setValue(new TextSection());
         }
         Set<Map.Entry<SectionType, Section>> after = resume.getSections();
-        doTest(Objects.equals(createResume().getSections(), after), ResumeTestData.class.getDeclaredMethods()[7].getName());
+        doTest(
+                Objects.equals(createResume().getSections(), after),
+                ResumeTestData.class.getDeclaredMethods()[7].getName()
+        );
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/creators/ContactsCreator.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/creators/ContactsCreator.java
@@ -1,0 +1,18 @@
+package ru.javawebinar.basejava.modelDataTest.creators;
+
+import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import static ru.javawebinar.basejava.model.enumKeyTypes.ContactType.*;
+
+public class ContactsCreator {
+    public static Set<Map.Entry<ContactType, String>> create() {
+        return new EnumMap<ContactType, String>(ContactType.class) {{
+            put(TEL, "+79218550482");
+            put(SKYPE, "skype:grigory.kislin");
+        }}.entrySet();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/creators/ResumeCreator.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/creators/ResumeCreator.java
@@ -1,0 +1,20 @@
+package ru.javawebinar.basejava.modelDataTest.creators;
+
+import ru.javawebinar.basejava.model.Resume;
+import ru.javawebinar.basejava.model.enumKeyTypes.ContactType;
+import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
+
+import java.util.EnumMap;
+
+public class ResumeCreator {
+    public static Resume createResume() {
+        return new Resume("Григорий Кислин") {{
+            setContacts(new EnumMap<>(ContactType.class) {{
+                ContactsCreator.create().forEach(contact -> this.put(contact.getKey(), contact.getValue()));
+            }});
+            setSections(new EnumMap<>(SectionType.class) {{
+                SectionsCreator.create().forEach(section -> this.put(section.getKey(), section.getValue()));
+            }});
+        }};
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/creators/SectionsCreator.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/creators/SectionsCreator.java
@@ -1,0 +1,24 @@
+package ru.javawebinar.basejava.modelDataTest.creators;
+
+import ru.javawebinar.basejava.model.enumKeyTypes.SectionType;
+import ru.javawebinar.basejava.model.interfaces.Section;
+import ru.javawebinar.basejava.modelDataTest.testData.*;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import static ru.javawebinar.basejava.model.enumKeyTypes.SectionType.*;
+
+public class SectionsCreator {
+    public static Set<Map.Entry<SectionType, Section>> create() {
+        return new EnumMap<SectionType, Section>(SectionType.class) {{
+            put(PERSONAL, Personal.createSection());
+            put(OBJECTIVE, Objective.createSection());
+            put(ACHIEVEMENT, Achievement.createSection());
+            put(QUALIFICATIONS, Qualifications.createSection());
+            put(EXPERIENCE, Experience.createSection());
+            put(EDUCATION, Education.createSection());
+        }}.entrySet();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Achievement.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Achievement.java
@@ -2,9 +2,14 @@ package ru.javawebinar.basejava.modelDataTest.testData;
 
 import ru.javawebinar.basejava.model.sections.ListStringSection;
 
+import java.util.ArrayList;
+
 public class Achievement {
 
     public static ListStringSection createSection() {
-        return new ListStringSection();
+        return new ListStringSection(new ArrayList<>() {{
+            add("Организация команды и успешная реализация Java проектов для сторонних заказчиков");
+            add("С 2013 года: разработка проектов \"Разработка Web приложения\",\"Java Enterprise\"");
+        }});
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Achievement.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Achievement.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.ListStringSection;
+
+public class Achievement {
+
+    public static ListStringSection createSection() {
+        return new ListStringSection();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
@@ -21,14 +21,14 @@ public class Education {
                 put(LINK, "https://www.ifmo.ru/");
             }}, new ArrayList<>() {{
                 add(new Info() {{
-                    addAll(new EnumMap<>(InfoType.class) {{
+                    save(new EnumMap<>(InfoType.class) {{
                         put(START, "09/1993");
                         put(END, "07/1996");
                         put(HEADER, "Аспирантура (программист С, С++)");
                     }});
                 }});
                 add(new Info() {{
-                    addAll(new EnumMap<>(InfoType.class) {{
+                    save(new EnumMap<>(InfoType.class) {{
                         put(START, "09/1987");
                         put(END, "07/1993");
                         put(HEADER, "Инженер (программист Fortran, C)");

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.ListItemSection;
+
+public class Education {
+
+    public static ListItemSection createSection() {
+        return new ListItemSection();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
@@ -2,9 +2,11 @@ package ru.javawebinar.basejava.modelDataTest.testData;
 
 import ru.javawebinar.basejava.model.sections.ListItemSection;
 
+import java.util.ArrayList;
+
 public class Education {
 
     public static ListItemSection createSection() {
-        return new ListItemSection();
+        return new ListItemSection(new ArrayList<>());
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Education.java
@@ -1,12 +1,41 @@
 package ru.javawebinar.basejava.modelDataTest.testData;
 
+import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
+import ru.javawebinar.basejava.model.item.Info;
+import ru.javawebinar.basejava.model.item.Item;
 import ru.javawebinar.basejava.model.sections.ListItemSection;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
+
+import static ru.javawebinar.basejava.model.enumKeyTypes.HeaderType.*;
+import static ru.javawebinar.basejava.model.enumKeyTypes.InfoType.*;
 
 public class Education {
 
     public static ListItemSection createSection() {
-        return new ListItemSection(new ArrayList<>());
+        return new ListItemSection(new ArrayList<>() {{
+            add(new Item(new EnumMap<>(HeaderType.class) {{
+                put(TITLE, "Санкт-Петербургский национальный исследовательский университет информационных технологий, механики и оптики");
+                put(LINK, "https://www.ifmo.ru/");
+            }}, new ArrayList<>() {{
+                add(new Info() {{
+                    addAll(new EnumMap<>(InfoType.class) {{
+                        put(START, "09/1993");
+                        put(END, "07/1996");
+                        put(HEADER, "Аспирантура (программист С, С++)");
+                    }});
+                }});
+                add(new Info() {{
+                    addAll(new EnumMap<>(InfoType.class) {{
+                        put(START, "09/1987");
+                        put(END, "07/1993");
+                        put(HEADER, "Инженер (программист Fortran, C)");
+                    }});
+                }});
+            }}));
+        }});
+
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
@@ -1,12 +1,36 @@
 package ru.javawebinar.basejava.modelDataTest.testData;
 
+import ru.javawebinar.basejava.model.enumKeyTypes.HeaderType;
+import ru.javawebinar.basejava.model.enumKeyTypes.InfoType;
+import ru.javawebinar.basejava.model.item.Info;
+import ru.javawebinar.basejava.model.item.Item;
 import ru.javawebinar.basejava.model.sections.ListItemSection;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
+
+import static ru.javawebinar.basejava.model.enumKeyTypes.HeaderType.*;
+import static ru.javawebinar.basejava.model.enumKeyTypes.InfoType.*;
 
 public class Experience {
 
     public static ListItemSection createSection() {
-        return new ListItemSection(new ArrayList<>());
+        return new ListItemSection(new ArrayList<>() {{
+            add(new Item(
+                    new EnumMap<>(HeaderType.class) {{
+                        put(TITLE, "Java Online Projects");
+                        put(LINK, "https://javaops.ru/");
+                    }},
+                    new ArrayList<>() {{
+                        add(new Info() {{
+                            addAll(new EnumMap<>(InfoType.class) {{
+                                put(START, "10/2013");
+                                put(END, "Сейчас");
+                                put(HEADER, "Автор проекта");
+                                put(DESCRIPTION, "Создание, организация и проведение Java онлайн проектов и стажировок.");
+                            }});
+                        }});
+                    }}));
+        }});
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
@@ -2,9 +2,11 @@ package ru.javawebinar.basejava.modelDataTest.testData;
 
 import ru.javawebinar.basejava.model.sections.ListItemSection;
 
+import java.util.ArrayList;
+
 public class Experience {
 
     public static ListItemSection createSection() {
-        return new ListItemSection();
+        return new ListItemSection(new ArrayList<>());
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.ListItemSection;
+
+public class Experience {
+
+    public static ListItemSection createSection() {
+        return new ListItemSection();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Experience.java
@@ -23,7 +23,7 @@ public class Experience {
                     }},
                     new ArrayList<>() {{
                         add(new Info() {{
-                            addAll(new EnumMap<>(InfoType.class) {{
+                            save(new EnumMap<>(InfoType.class) {{
                                 put(START, "10/2013");
                                 put(END, "Сейчас");
                                 put(HEADER, "Автор проекта");

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Objective.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Objective.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.TextSection;
+
+public class Objective {
+
+    public static TextSection createSection() {
+        return new TextSection();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Objective.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Objective.java
@@ -5,6 +5,6 @@ import ru.javawebinar.basejava.model.sections.TextSection;
 public class Objective {
 
     public static TextSection createSection() {
-        return new TextSection();
+        return new TextSection("Ведущий стажировок и корпоративного обучения по Java Web и Enterprise технологиям");
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Personal.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Personal.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.TextSection;
+
+public class Personal {
+
+    public static TextSection createSection() {
+        return new TextSection();
+    }
+}

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Personal.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Personal.java
@@ -5,6 +5,8 @@ import ru.javawebinar.basejava.model.sections.TextSection;
 public class Personal {
 
     public static TextSection createSection() {
-        return new TextSection();
+        return new TextSection(
+                "Аналитический склад ума, сильная логика, креативность, инициативность. Пурист кода и архитектуры."
+        );
     }
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Qualifications.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Qualifications.java
@@ -2,9 +2,13 @@ package ru.javawebinar.basejava.modelDataTest.testData;
 
 import ru.javawebinar.basejava.model.sections.ListStringSection;
 
+import java.util.ArrayList;
+
 public class Qualifications {
     public static ListStringSection createSection() {
-        return new ListStringSection();
+        return new ListStringSection(new ArrayList<>() {{
+            add("JEE AS: GlassFish (v2.1, v3), OC4J, JBoss, Tomcat, Jetty, WebLogic, WSO2");
+            add("Version control: Subversion, Git, Mercury, ClearCase, Perforce");
+        }});
     }
-
 }

--- a/src/ru/javawebinar/basejava/modelDataTest/testData/Qualifications.java
+++ b/src/ru/javawebinar/basejava/modelDataTest/testData/Qualifications.java
@@ -1,0 +1,10 @@
+package ru.javawebinar.basejava.modelDataTest.testData;
+
+import ru.javawebinar.basejava.model.sections.ListStringSection;
+
+public class Qualifications {
+    public static ListStringSection createSection() {
+        return new ListStringSection();
+    }
+
+}


### PR DESCRIPTION
Решение:
Информация в разделах Resume - множество пар ключ-значение.
Пары разделены на группы по типу информации.
Для каждой группы определен тип ключа (KeyType) в виде перечисления:
SectionType, ContactType, HeaderType, InfoType.

Для хранения данных и манипуляций с ними выделены сущности:
абстракции Chapter< K extends Enum < K >, V > и Section< T > и класс Item.

Решение строится на комбинировании конкретных реализаций абстракций между собой.

Например:
     реализация Chapter(SectionType) - Sections содержит реализацию Section - ListItemSection(extends AbstractListSection< T >) для хранения информации об образовании или об опыте работы, где T - Item,
a Item содержит: 
    1 - реализацию Chapter(HeaderType) - Header (название и ссылка),
    2 - реализацию Section - ListInfoSection (extends AbstractListSection< T >) для хранения блоков информации о разных периодах времени в одной организации, где T - реализация Chapter(InfoType) - Info (дата начала, дата завершения, заголовок, комментарий).

Трудности:

1) Передать данные из Resume таким образом, чтобы исключить возможность изменить содержимое Resume в обход метода update(Resume r) интерфейса Storage.

Решение:
метод getContent() класса AbstractListSection возвращает unmodifiable List;
метод getAll() класса AbstractEnumChapter возвращает unmodifiable Set;
метод save() класса AbstractEnumChapter бросает UnsupportedOperationException, если данные в разделе уже существуют.

2) Проверка корректности сохранения и извлечения данных при описанной выше структуре. Я в дебаггере вижу, что данные одинаковые, o1.toString().equals(o2.toString()) возвращает true, а equals у ListSection не работает.

Решение:
Поскольку сортировка данных внутри секций не нужна, выбрал вариант сравнивать не сортированные списки внутри метода equals класса AbstractListSection путем подсчета кол-ва вхождений, используя переопределенный hashCode() содержимого.
